### PR TITLE
Fix dataframe.assign in plotting.py

### DIFF
--- a/experiment_analysis/plotting.py
+++ b/experiment_analysis/plotting.py
@@ -96,15 +96,15 @@ def get_timeseries(
             elif method == TimeseriesMethod.CUPED_CAPPED:
                 df_agg_metric = df_agg_metric.assign(**{
                         f"{metric}_cuped": apply_cuped(df_agg_metric, metric, f"{covariate_prefix}_{metric}"),
-                        f"{metric}_cuped_capped": apply_capping(df_agg_metric,
+                        f"{metric}_cuped_capped": lambda df_agg_metric: apply_capping(df_agg_metric,
                                                                 metric=f"{metric}_cuped",
                                                                 method=CappingMethod.WITH_CUPED,
                                                                 metric_raw=metric)})
             elif method == TimeseriesMethod.ISOTONIC_CAPPED:
                 df_agg_metric = df_agg_metric.assign(**{
                         f"{metric}_isotonic": apply_isotonic(df_agg_metric, metric, f"{covariate_prefix}_{metric}"),
-                        f"{metric}_isotonic_capped": apply_capping(df_agg_metric,
-                                                                metric=f"{metric}_isotoic",
+                        f"{metric}_isotonic_capped": lambda df_agg_metric: apply_capping(df_agg_metric,
+                                                                metric=f"{metric}_isotonic",
                                                                 method=CappingMethod.WITH_ISOTONIC,
                                                                 metric_raw=metric)})
 


### PR DESCRIPTION
Fix `dataframe.assign` in plotting.py. While chaining assign we need to use `lambda function` to refer to newly created columns, otherwise will return error.

<img width="617" alt="Screenshot 2023-06-30 at 11 35 22 AM" src="https://github.com/Faire/experiment-analysis/assets/113390169/748e2a89-e2f6-447f-91ea-3599196c62ed">
